### PR TITLE
Abort remote gallery fetch on unmount

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,12 +18,14 @@ function useRemoteGallery(url: string) {
   const [items, setItems] = React.useState<GalleryImage[]>([]);
   useEffect(() => {
     let alive = true;
-    fetch(url, { cache: 'no-store' })
+    const controller = new AbortController();
+    fetch(url, { cache: 'no-store', signal: controller.signal })
       .then(r => (r.ok ? r.json() : Promise.reject(r)))
       .then((arr: GalleryImage[]) => {
         if (alive && Array.isArray(arr)) setItems(arr);
       })
-      .catch(() => {
+      .catch(err => {
+        if (err.name === 'AbortError') return;
         // minimal safe fallback so the page is never empty
         setItems([
           {
@@ -35,6 +37,7 @@ function useRemoteGallery(url: string) {
       });
     return () => {
       alive = false;
+      controller.abort();
     };
   }, [url]);
   return items;


### PR DESCRIPTION
## Summary
- cancel in-flight gallery fetch requests with AbortController

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b94be2b42883209730ce79a27a9d92