### PR TITLE
feat: specify sizes for about image

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -227,6 +227,7 @@ export default function Page() {
               src="/photos/me.jpg"
               alt="Portrait of Joe Rey"
               fill
+              sizes="(max-width: 768px) 100vw, 33vw"
               className="object-cover rounded-2xl ring-1 ring-neutral-800"
               priority={false}
             />


### PR DESCRIPTION
## Summary
- specify responsive `sizes` for the about portrait image so browsers can choose optimal resolutions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b94bc6acc08320ab7a5b48cc8c1632