### PR TITLE
feat: update site tagline

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,12 +21,12 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   title: "Joe Rey Photography",
-  description: "Story-driven images that actually feel like the moment.",
+  description: "Joe Rey Photography | UK landscapes, cityscapes, macro, prints",
   metadataBase: new URL("https://www.joereyphotography.com"),
   alternates: { canonical: "/" },
   openGraph: {
     title: "Joe Rey Photography",
-    description: "Story-driven images that actually feel like the moment.",
+    description: "Joe Rey Photography | UK landscapes, cityscapes, macro, prints",
     url: "https://www.joereyphotography.com",
     siteName: "Joe Rey Photography",
     // your logo as the preview image
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Joe Rey Photography",
-    description: "Story-driven images that actually feel like the moment.",
+    description: "Joe Rey Photography | UK landscapes, cityscapes, macro, prints",
     images: ["/photos/logo.png"],
   },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ const site = {
   hero: {
     image: '/photos/Gap.jpg', // keep this in /public/photos
     logo: '/photos/logo.png', // top-left logo
-    headline: 'Story-driven images that actually feel like the moment',
+    headline: 'UK landscapes, cityscapes, macro, prints',
     sub: 'A hand-picked set of favourites from my Clickasnap portfolio.',
     ctaPrimary: { label: 'View portfolio', href: '#portfolio' },
     ctaSecondary: { label: 'Book a shoot', href: '#contact' },
@@ -103,7 +103,10 @@ export default function Page() {
 
   {/* hero text + buttons */}
   <div className="relative z-10 max-w-3xl px-6 pt-24 sm:pt-0">
-    <h1 className="text-3xl sm:text-5xl font-bold">{site.hero.headline}</h1>
+    <h1 className="text-3xl sm:text-5xl font-bold">
+      <span className="block">{site.name}</span>
+      <span className="block">{site.hero.headline}</span>
+    </h1>
     <p className="mt-3 text-lg text-neutral-300">{site.hero.sub}</p>
 
     <div className="mt-6 flex flex-col sm:flex-row gap-4 justify-center">


### PR DESCRIPTION
## Summary
- update hero headline to new Joe Rey Photography tagline
- replace metadata descriptions with new tagline
- split hero heading into site title and tagline on separate lines

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9561bdbf48320be6a12f4a8b856f6