### PR TITLE
feat(analytics): add Google Analytics via gtag with route tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Analytics
+
+GA enabled. Check Realtime in GA after deploy.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,10 @@
 // app/layout.tsx
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
+import Analytics from "@/components/Analytics";
+import * as gtag from "@/lib/gtag";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -48,7 +51,27 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        {gtag.GA_ID && (
+          <>
+            <Script
+              id="ga-loader"
+              strategy="afterInteractive"
+              src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_ID}`}
+            />
+            <Script id="ga-init" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${gtag.GA_ID}', { page_path: window.location.pathname });
+              `}
+            </Script>
+          </>
+        )}
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        {gtag.GA_ID && <Analytics />}
         {children}
       </body>
     </html>

--- a/components/Analytics.tsx
+++ b/components/Analytics.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import * as gtag from "@/lib/gtag";
+
+export default function Analytics() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const url = pathname + (searchParams.toString() ? `?${searchParams}` : "");
+    gtag.pageview(url);
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,0 +1,16 @@
+export const GA_ID: string = process.env.NEXT_PUBLIC_GA_ID ?? "";
+
+if (!GA_ID && process.env.NODE_ENV === "development") {
+  console.warn("NEXT_PUBLIC_GA_ID is not set");
+}
+
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+export const pageview = (url: string) => {
+  if (!GA_ID || typeof window === "undefined") return;
+  window.gtag("config", GA_ID, { page_path: url });
+};


### PR DESCRIPTION
## Summary
- add gtag helper and analytics listener for route tracking
- load Google Analytics scripts in root layout with safeguards
- document GA enablement in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9c5882fc08320856ff7949330ea1a